### PR TITLE
Establish one to many relationship between center and holiday models

### DIFF
--- a/src/prisma/client.ts
+++ b/src/prisma/client.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+
+export const prismaClient = new PrismaClient();

--- a/src/prisma/migrations/20250619082652_one_to_many_center_holidays/migration.sql
+++ b/src/prisma/migrations/20250619082652_one_to_many_center_holidays/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `centerId` to the `holidays` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `holidays` ADD COLUMN `centerId` VARCHAR(191) NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE `holidays` ADD CONSTRAINT `holidays_centerId_fkey` FOREIGN KEY (`centerId`) REFERENCES `centers`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -14,12 +14,13 @@ datasource db {
 }
 
 model Center {
-  id            String   @id @default(uuid())
-  name          String   @unique
+  id            String    @id @default(uuid())
+  name          String    @unique
   location      String
   contactNumber String?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  holidays      Holiday[]
 
   @@map("centers")
 }
@@ -30,6 +31,8 @@ model Holiday {
   date      DateTime @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  center    Center   @relation(fields: [centerId], references: [id])
+  centerId  String
 
   @@map("holidays")
 }


### PR DESCRIPTION
## 📌 Summary

This PR establishes a one-to-many relationship between `centers` and `holidays` in the database schema using Prisma. Each holiday record is now associated with a specific center.

---

## 🛠 Changes Made

### Prisma Schema (`schema.prisma`)
- **Holiday model:**
  - Added `centerId` field of type `String`.
  - Added `center` relation to `Center`.
- **Center model:**
  - Added `holidays` field of type `Holiday[]` to reflect the one-to-many relationship.

#### 🧱 Updated Models 

```prisma
model Center {
  id            String    @id @default(uuid())
  name          String    @unique
  location      String
  contactNumber String?
  createdAt     DateTime  @default(now())
  updatedAt     DateTime  @updatedAt
  holidays      Holiday[]

  @@map("centers")
}

model Holiday {
  id        String   @id @default(uuid())
  name      String
  date      DateTime @unique
  createdAt DateTime @default(now())
  updatedAt DateTime @updatedAt
  center    Center   @relation(fields: [centerId], references: [id])
  centerId  String

  @@map("holidays")
}

