### PR TITLE
Create Center API Endpoint

### DIFF
--- a/src/controllers/center.controller.ts
+++ b/src/controllers/center.controller.ts
@@ -1,8 +1,12 @@
 import { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
-import { logger } from "../config/logger.config";
+import { createCenterService } from "../services/center.service";
 
 export const createCenterHandler = async (req: Request, res: Response, next: NextFunction) => {
-    logger.info("Inside createCenterHandler!");
-    res.status(StatusCodes.NOT_IMPLEMENTED).send("Not yet implemented!");
+    const center = await createCenterService(req.body);
+    res.status(StatusCodes.CREATED).json({
+        success: true,
+        message: "Center created successfully!",
+        data: center
+    })
 }

--- a/src/controllers/center.controller.ts
+++ b/src/controllers/center.controller.ts
@@ -1,0 +1,8 @@
+import { NextFunction, Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import { logger } from "../config/logger.config";
+
+export const createCenterHandler = async (req: Request, res: Response, next: NextFunction) => {
+    logger.info("Inside createCenterHandler!");
+    res.status(StatusCodes.NOT_IMPLEMENTED).send("Not yet implemented!");
+}

--- a/src/repositories/center.repository.ts
+++ b/src/repositories/center.repository.ts
@@ -1,7 +1,7 @@
 import { Prisma } from "@prisma/client";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { prismaClient } from "../prisma/client";
-import { InternalServerError } from "../utils/errors/app.error";
+import { ConflictError } from "../utils/errors/app.error";
 
 export const createCenter = async (paylod: Prisma.CenterCreateInput) => {
     try {
@@ -18,7 +18,7 @@ export const createCenter = async (paylod: Prisma.CenterCreateInput) => {
     } catch (error) {
         if (error instanceof PrismaClientKnownRequestError) {
             if (error.code === 'P2002') {
-                throw new InternalServerError("A center with this name already exists. Please choose a different name")
+                throw new ConflictError("A center with this name already exists. Please choose a different name")
             }
         }
     }

--- a/src/repositories/center.repository.ts
+++ b/src/repositories/center.repository.ts
@@ -1,0 +1,25 @@
+import { Prisma } from "@prisma/client";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+import { prismaClient } from "../prisma/client";
+import { InternalServerError } from "../utils/errors/app.error";
+
+export const createCenter = async (paylod: Prisma.CenterCreateInput) => {
+    try {
+        const center = await prismaClient.center.create({
+            data: paylod,
+            select: {
+                id: true,
+                name: true,
+                location: true,
+                contactNumber: true
+            }
+        });
+        return center;
+    } catch (error) {
+        if (error instanceof PrismaClientKnownRequestError) {
+            if (error.code === 'P2002') {
+                throw new InternalServerError("A center with this name already exists. Please choose a different name")
+            }
+        }
+    }
+}

--- a/src/routers/v1/center.router.ts
+++ b/src/routers/v1/center.router.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import { createCenterHandler } from '../../controllers/center.controller';
+import { validateRequetBody } from '../../validators';
+import { createCenterSchema } from '../../validators/center.validator';
+
+const centerRouter = express.Router();
+
+centerRouter.post('/', validateRequetBody(createCenterSchema), createCenterHandler);
+
+
+export default centerRouter;

--- a/src/routers/v1/index.ts
+++ b/src/routers/v1/index.ts
@@ -1,7 +1,7 @@
 import express from 'express';
+import centerRouter from './center.router';
 
 const router = express.Router();
-
-
+router.use('/centers', centerRouter);
 
 export default router;

--- a/src/services/center.service.ts
+++ b/src/services/center.service.ts
@@ -1,0 +1,7 @@
+import { Prisma } from "@prisma/client";
+import { createCenter } from "../repositories/center.repository";
+
+export const createCenterService = async (paylod: Prisma.CenterCreateInput) => {
+    const center = await createCenter(paylod);
+    return center;
+}

--- a/src/validators/center.validator.ts
+++ b/src/validators/center.validator.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+const e164PhoneRegex: RegExp = /^\+?[1-9]\d{1,14}$/;
+
+export const createCenterSchema = z.object({
+    name: z.string({ message: "name is required!" }),
+    location: z.string({ message: "location is required!" }),
+    contactNumber: z.string().regex(e164PhoneRegex, { message: 'Invalid E.164 phone number format' }).optional()
+});


### PR DESCRIPTION
## ✨ Summary

This PR implements the full stack for the `POST /centers` endpoint including validation, service logic, and database integration via Prisma.

---

### 🔧 Changes Summary

#### ✅ Controller
- Added `createCenterHandler` in `src/controllers/center.controller.ts`
- Handles the HTTP request and sends response with HTTP `201 CREATED` on success

#### ✅ Service Layer
- Created `createCenterService` in `src/services/center.service.ts`
- Decouples controller from direct DB operations

#### ✅ Repository Layer
- Added `createCenter` in `src/repositories/center.repository.ts`
- Uses Prisma to create a center
- Handles unique constraint violation (`P2002`) gracefully

#### ✅ Validation
- Defined schema using `Zod` in `src/validators/center.validator.ts`
- Fields:
  - `name` (string, required)
  - `location` (string, required)
  - `contactNumber` (string, optional, must follow E.164 format)

#### ✅ Routing
- Registered new route in `src/routers/v1/center.router.ts`
- Hooked up with API version router in `src/routers/v1/index.ts`

---

### 📂 Files Added or Modified

- `controllers/center.controller.ts`
- `services/center.service.ts`
- `repositories/center.repository.ts`
- `routers/v1/center.router.ts`
- `routers/v1/index.ts` (modified to include center route)
- `validators/center.validator.ts`

---

### ⚠️ Error Handling

- If a center with the same name exists, returns a `409 ConflictError` with message: `A center with this name already exists. Please choose a different name`
