### PR TITLE
Add unique constraint on holidays table for centerId and date

### DIFF
--- a/src/prisma/migrations/20250619205451_add_unique_key_to_holiday/migration.sql
+++ b/src/prisma/migrations/20250619205451_add_unique_key_to_holiday/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[centerId,date]` on the table `holidays` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX `holidays_date_key` ON `holidays`;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `holidays_centerId_date_key` ON `holidays`(`centerId`, `date`);

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -28,11 +28,12 @@ model Center {
 model Holiday {
   id        String   @id @default(uuid())
   name      String
-  date      DateTime @unique
+  date      DateTime 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   center    Center   @relation(fields: [centerId], references: [id])
   centerId  String
 
+  @@unique([centerId,date])
   @@map("holidays")
 }


### PR DESCRIPTION
## 📦 Feature: Add unique constraint on `holidays` table for `centerId` and `date`

This update introduces a composite unique constraint to the `holidays` table, ensuring that each holiday date is unique per center. This prevents duplicate holiday entries for the same center on the same date.

### 🔄 Changes

- **Dropped**: Existing unique index on `date` (`holidays_date_key`)
- **Added**: New composite unique index on (`centerId`, `date`) as `holidays_centerId_date_key`

 #### 🧱 Before Changes:

```
model Holiday {
  id        String   @id @default(uuid())
  name      String
  date      DateTime @unique
  createdAt DateTime @default(now())
  updatedAt DateTime @updatedAt
  center    Center   @relation(fields: [centerId], references: [id])
  centerId  String

  @@map("holidays")
}
```

#### 🧱 After Changes:

```
model Holiday {
  id        String   @id @default(uuid())
  name      String
  date      DateTime 
  createdAt DateTime @default(now())
  updatedAt DateTime @updatedAt
  center    Center   @relation(fields: [centerId], references: [id])
  centerId  String

  @@unique([centerId,date])
  @@map("holidays")
}
```