### PR TITLE
Enable Cascade Delete for Holidays

### DIFF
--- a/src/prisma/migrations/20250620070930_delete_cascade_holiday/migration.sql
+++ b/src/prisma/migrations/20250620070930_delete_cascade_holiday/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE `holidays` DROP FOREIGN KEY `holidays_centerId_fkey`;
+
+-- AddForeignKey
+ALTER TABLE `holidays` ADD CONSTRAINT `holidays_centerId_fkey` FOREIGN KEY (`centerId`) REFERENCES `centers`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -28,12 +28,12 @@ model Center {
 model Holiday {
   id        String   @id @default(uuid())
   name      String
-  date      DateTime 
+  date      DateTime
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  center    Center   @relation(fields: [centerId], references: [id])
+  center    Center   @relation(fields: [centerId], references: [id], onDelete: Cascade)
   centerId  String
 
-  @@unique([centerId,date])
+  @@unique([centerId, date])
   @@map("holidays")
 }


### PR DESCRIPTION
### 📋 Summary

This PR updates the Prisma schema and migration files to enable **cascade delete behavior** for the `Holiday` model when its related `Center` is deleted. This ensures data consistency and avoids orphaned holiday records.

---

### 🛠️ Changes Made

#### 📄 `schema.prisma`
- Updated the `Holiday.center` relation to:
  ```prisma
  center Center @relation(fields: [centerId], references: [id], onDelete: Cascade)
