### PR TITLE
Implement Delete Center API

### DIFF
--- a/src/controllers/center.controller.ts
+++ b/src/controllers/center.controller.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
-import { createCenterService, getAllCentersService, getCenterByIdService, updateCenterService } from "../services/center.service";
+import { createCenterService, deleteCenterByIdService, getAllCentersService, getCenterByIdService, updateCenterService } from "../services/center.service";
 import { validate as isValidUUID } from "uuid";
 import { BadRequestError } from "../utils/errors/app.error";
 
@@ -23,7 +23,6 @@ export const updateCenterHandler = async (req: Request, res: Response, next: Nex
         message: "Center created successfully!",
         data: center
     });
-    res.status(StatusCodes.NOT_IMPLEMENTED).send("Not yet implemented!");
 }
 
 export const getAllCenterHandler = async (req: Request, res: Response, next: NextFunction) => {
@@ -44,5 +43,16 @@ export const getCenterHandler = async (req: Request, res: Response, next: NextFu
         success: true,
         message: `Successfully got center with id: ${req.params.id}!`,
         data: center
+    });
+}
+
+export const deleteCenterHandler = async (req: Request, res: Response, next: NextFunction) => {
+    if (!isValidUUID(req.params.id)) {
+        throw new BadRequestError("Id is not a valid uuid!");
+    }
+    const response = await deleteCenterByIdService(req.params.id);
+    res.status(StatusCodes.CREATED).json({
+        success: response,
+        message: `Successfully deleted center with id: ${req.params.id}!`
     });
 }

--- a/src/repositories/center.repository.ts
+++ b/src/repositories/center.repository.ts
@@ -58,7 +58,6 @@ export const getAllCenters = async () => {
     return centers;
 }
 
-
 export const getCenterById = async (id: string) => {
     const center = await prismaClient.center.findUnique({
         where: { id: id },
@@ -74,3 +73,20 @@ export const getCenterById = async (id: string) => {
     }
     return center;
 }
+
+export const deleteCenterById = async (id: string) => {
+    try {
+        await prismaClient.center.delete({
+            where: {
+                id: id
+            }
+        });
+        return true;
+    } catch (error) {
+        if (error instanceof PrismaClientKnownRequestError) {
+            if (error.code === 'P2025') {
+                throw new ConflictError(`No center found with id: ${id}`);
+            }
+        }
+    }
+};

--- a/src/routers/v1/center.router.ts
+++ b/src/routers/v1/center.router.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { createCenterHandler, getAllCenterHandler, getCenterHandler, updateCenterHandler } from '../../controllers/center.controller';
+import { createCenterHandler, deleteCenterHandler, getAllCenterHandler, getCenterHandler, updateCenterHandler } from '../../controllers/center.controller';
 import { validateRequetBody } from '../../validators';
 import { createCenterSchema, updateCenterSchema } from '../../validators/center.validator';
 
@@ -9,6 +9,7 @@ centerRouter.post('/', validateRequetBody(createCenterSchema), createCenterHandl
 centerRouter.patch('/:id', validateRequetBody(updateCenterSchema), updateCenterHandler);
 centerRouter.get('/', getAllCenterHandler);
 centerRouter.get('/:id', getCenterHandler);
+centerRouter.delete('/:id', deleteCenterHandler);
 
 
 export default centerRouter;

--- a/src/services/center.service.ts
+++ b/src/services/center.service.ts
@@ -1,5 +1,5 @@
 import { Prisma } from "@prisma/client";
-import { createCenter, getAllCenters, getCenterById, updateCenter } from "../repositories/center.repository";
+import { createCenter, deleteCenterById, getAllCenters, getCenterById, updateCenter } from "../repositories/center.repository";
 
 export const createCenterService = async (paylod: Prisma.CenterCreateInput) => {
     const center = await createCenter(paylod);
@@ -18,5 +18,10 @@ export const getAllCentersService = async () => {
 
 export const getCenterByIdService = async (id: string) => {
     const center = await getCenterById(id);
+    return center;
+}
+
+export const deleteCenterByIdService = async (id: string) => {
+    const center = await deleteCenterById(id);
     return center;
 }


### PR DESCRIPTION
### 📋 Summary

This PR implements the ability to delete a `Center` record via API. It includes updates to the controller, service, repository, and router layers.

When a center is deleted:
- Its record is removed from the database.
- Thanks to cascade rules (from previous PR), all related holidays are automatically deleted.

---

### 🛠️ Changes Made

- **Controller**: Added `deleteCenterHandler` with UUID validation and success response.
- **Service Layer**: Introduced `deleteCenterByIdService` to handle business logic.
- **Repository**: Added `deleteCenterById` with error handling for non-existent center (Prisma error `P2025`).
- **Router**: Registered `DELETE /centers/:id` route.

---

### ✅ API Usage

```http
DELETE /centers/:id
